### PR TITLE
V2016.2

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,11 +8,11 @@
   -- Shorthand of the community.
   site_code = 'ffkbu',
   opkg = {
-  openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
+  openwrt = 'http://opkg.services.ffeh/openwrt/%n/%v/%S/packages',
   extra = {
-	modules = '',
-	},
-   },
+    modules = 'http://opkg.services.ffeh/modules/gluon-%GS-%GR/%S',
+  },
+}
 
   -- Prefixes used within the mesh. Both are required.
   prefix4 = '10.159.0.0/18',

--- a/site.conf
+++ b/site.conf
@@ -151,6 +151,6 @@
 
   -- Skip setup mode (config mode) on first boot
     setup_mode = {
-        skip = true,
+        skip = false,
     },
 }

--- a/site.conf
+++ b/site.conf
@@ -1,18 +1,11 @@
 {
-  -- Used for generated hostnames, e.g. freifunk-abcdef123456.
   hostname_prefix = 'ffkbu-',
-
-  -- Name of the community.
   site_name = 'Freifunk KBU Hood Bonn',
-
-  -- Shorthand of the community.
   site_code = 'ffkbu',
-  opkg = {
-  openwrt = 'http://opkg.services.ffeh/openwrt/%n/%v/%S/packages',
-  extra = {
-    modules = 'http://opkg.services.ffeh/modules/gluon-%GS-%GR/%S',
-  },
-}
+  
+	opkg = {
+		openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
+	},
 
   -- Prefixes used within the mesh. Both are required.
   prefix4 = '10.159.0.0/18',
@@ -24,36 +17,46 @@
 
   -- List of NTP servers in your community.
   -- Must be reachable using IPv6!
-  ntp_servers = {'2.pool.ntp.org'},
+  ntp_servers = {
+    '2.pool.ntp.org',
+    '0.openwrt.pool.ntp.org',
+    '1.openwrt.pool.ntp.org',
+    '2.openwrt.pool.ntp.org',
+    '3.openwrt.pool.ntp.org',
+  },
 
   -- Wireless regulatory domain of your community.
   regdom = 'DE',
 
-  -- Wireless configuratoin for 2.4 GHz interfaces.
+  -- Wireless configuration for 2.4 GHz interfaces.
   wifi24 = {
-        channel = 1,
-	ap = {
-	    	ssid = 'kbu.freifunk.net',
-             },
- 	ibss = {
-	        ssid = '02:d1:11:37:fc:39',  -- ESSID used for mesh
-    		bssid = '02:d1:11:37:fc:39', -- BSSID used for mesh
-   		mcast_rate = 12000,
-               },
-	    },
+    -- Wireless channel.
+    channel = 1,
+    ap = {
+            -- ESSID used for client network.
+            ssid = 'kbu.freifunk.net',
+        },
+        ibss ={
+            ssid = '02:d1:11:37:fc:39',  -- ESSID used for mesh
+            bssid = '02:d1:11:37:fc:39', -- BSSID used for mesh
+            -- Bitrate used for multicast/broadcast packets.
+            mcast_rate = 12000,
+        },
+  },
 
+  -- Wireless configuration for 5 GHz interfaces.
+  -- This should be equal to the 2.4 GHz variant, except for channel.
   wifi5 = {
-    channel = 44,
-	ap = {
-		    ssid = 'kbu.freifunk.net',
-    	     },
-      ibss = {
-		    ssid = '02:d1:11:37:fc:59',
-		    bssid = '02:d1:11:37:fc:59',
-		    mcast_rate = 12000,
-	  },
-},
-
+        channel = 44,
+        ap = {
+            ssid = 'kbu.freifunk.net',
+        },
+        ibss ={
+        ssid = '02:d1:11:37:fc:59',  -- ESSID used for mesh
+        bssid = '02:d1:11:37:fc:59',  -- BSSID used for mesh
+        mcast_rate = 12000,
+        },
+  },
   -- The next node feature allows clients to always reach the node it is
   -- connected to using a known IP address.
   next_node = {
@@ -70,130 +73,84 @@
   fastd_mesh_vpn = {
     -- List of crypto-methods to use.
     methods = {'salsa2012+umac'},
-    mtu = 1312,
     configurable = true,
     enabled = true,
-
+    mtu = 1312,
     bandwidth_limit = {
-   			 enabled = false,
- 			   ingress = 3000,
- 			   egress = 384,
-    		    },
+                enabled = false,
+                ingress = 3000,
+                egress = 384,
+        },
     groups = {
-	backbone = {
+    backbone = {
           -- Limit number of connected peers to reduce bandwidth.
-          limit = 2,
-
-          -- List of peers.
-          peers = {
-            fastd1 = {
+        limit = 2,
+        peers = {
+          fastd1 = {
               key = '657af03e36ff1b8bbe5a5134982a4f110c8523a9a63293870caf548916a95a03',
               remotes = {'ipv4 "fastd1.kbu.freifunk.net" port 10002'},
-	    },
-	    fastd2 = {
+          },
+          fastd2 = {
               key = '93654269a9ad0763851ed930e47a453b70bcbb874879e5c1f639df3f44d72d31',
               remotes = {'ipv4 "fastd2.kbu.freifunk.net" port 10002'},
-            },
-	    fastd3 = {
+          },
+          fastd3 = {
               key = 'd56181dfe9b5ac7cfe68a94c0ce406322a9924286a751673da0dcb28ad5218b0',
               remotes = {'ipv4 "fastd3.kbu.freifunk.net" port 10002'},
-	    },
-	    fastd4 = {
-	      key = '9b3f65f99963343e2785c8c4fad65e70b73ee7e1205d63bd84f3e2decb53e621',
-	      remotes = {'ipv4 "fastd4.kbu.freifunk.net" port 10002'},
-	    },
-	    fastd5 = {
-	      key = '6e4546121d16e7189715aef8ceb78ab58d59462720969318445f97b4301374d1',
-	      remotes = {'ipv4 "fastd5.kbu.freifunk.net" port 10002'},
-	    },
-	    fastd6 = {
-	      key = '2a2c69dbb3b9fd90d7eb8e2f70be70b472d811cd4f3743ad9f5002d14b5c94cd',
-	      remotes = {'ipv4 "fastd6.kbu.freifunk.net" port 10002'},
-	    },
-	    fastd7 = {
-	      key = '68de6815a89270c8eaf7832deedb8da098aad2ae5793cd2cd55dec3541ad28f2',
-	      remotes = {'ipv4 "fastd7.kbu.freifunk.net" port 10002'},
-   	    },
-	    fastd8 = {
-	      key = 'b41a9714b1178ce428b15af0b6055cc204b39af2088ef3b371d8c36219eedd1e',
-	      remotes = {'ipv4 "fastd8.kbu.freifunk.net" port 10002'},
-	    },
+          },
+          fastd4 = {
+              key = '9b3f65f99963343e2785c8c4fad65e70b73ee7e1205d63bd84f3e2decb53e621',
+              remotes = {'ipv4 "fastd4.kbu.freifunk.net" port 10002'},
+          },
+          fastd5 = {
+              key = '6e4546121d16e7189715aef8ceb78ab58d59462720969318445f97b4301374d1',
+              remotes = {'ipv4 "fastd5.kbu.freifunk.net" port 10002'},
+          },
+          fastd6 = {
+              key = '2a2c69dbb3b9fd90d7eb8e2f70be70b472d811cd4f3743ad9f5002d14b5c94cd',
+              remotes = {'ipv4 "fastd6.kbu.freifunk.net" port 10002'},
+          },
+          fastd7 = {
+              key = '68de6815a89270c8eaf7832deedb8da098aad2ae5793cd2cd55dec3541ad28f2',
+              remotes = {'ipv4 "fastd7.kbu.freifunk.net" port 10002'},
+          },
+          fastd8 = {
+              key = 'b41a9714b1178ce428b15af0b6055cc204b39af2088ef3b371d8c36219eedd1e',
+              remotes = {'ipv4 "fastd8.kbu.freifunk.net" port 10002'},
+          },
         },
-     },
+      },
     },
   },
- autoupdater = {
-    -- Default branch. Don't forget to set GLUON_BRANCH when building!
+  autoupdater = {
     branch = 'noupdate',
-
-    -- List of branches. You may define multiple branches.
     branches = {
-      stable = {
+      noupdate = {
         name = 'noupdate',
-
-        -- List of mirrors to fetch images from. IPv6 required!
         mirrors = {'http://'},
-
-        -- Number of good signatures required.
-        -- Have multiple maintainers sign your build and only
-        -- accept it when a sufficient number of them have
-        -- signed it.
         good_signatures = 9001,
-
-        -- List of public keys of maintainers.
         pubkeys = {
-                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Mr.X (Noone)
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Alice
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Bob
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Mary
         },
       },
     },
   },
 
+  -- Node roles
+  -- roles = {
+  --   default = 'node',
+  --   list = {
+  --     'node',
+  --     'test',
+  --     'backbone',
+  --     'service',
+  --   },
+  -- },
 
-
-
- 
-
--- skip setup on first boot
-setup_mode = {
-    skip = true,
+  -- Skip setup mode (config mode) on first boot
+    setup_mode = {
+        skip = true,
     },
-
-
-
-
-
-  -- These strings are shown in config mode. Some HTML is permissible.
-  --
-  -- msg_welcome: shown at startup
-  -- msg_pubkey:  shown when VPN is enabled
-  -- msg_reboot:  shown during reboot (after finishing configuration)
-  --
-  -- You may use some variables, e.g.:
-  --
-  -- <%=hostname%>               - the node's hostname
-  -- <%=pubkey%>                - the fastd public key
-  -- <%=sysconfig.primary_mac%> - the node's primary MAC
-  config_mode = {
-    msg_welcome = [[
-Willkommen zu Rampone's KBU Freifunk Gluon Test. First of all do not panic. 
-Um Internet Uplink zu nutzen, bitte unten "mesh vpn" anschalten. Geokoordinaten und Routername kann man zukunftssicher schon hier eintragen.
-Dennoch sollte man auch bei register.kbu.freifunk.net sich anmelden, falls dies moeglich ist. Der Routername wird als Hostnamen im LAN genutzt.
-]],
-    msg_pubkey = [[
-Dies ist der öffentliche VPN Schlüssel deines Freifunk-Knotens. Der ist bei KBU egal. KBU akzeptiert jegliche Schluessel. Der Router prueft 
-aber weiterhin automatisch den VPN-Schluessel der KBU Server.
-]],
-    msg_reboot = [[
-<p>
-Dein Knoten startet gerade neu und wird anschließend versuchen,
-sich mit anderen Freifunk-Knoten in seiner Nähe zu
-verbinden und/oder sich mit KBU's VPN Servern connecten. Weitere Informationen zur
-KBU Freifunk-Community findest du auf
-<a href="https://kbu.freifunk.net/">unserer Webseite</a>.
-</p>
-<p>
-Viel Spaß mit deinem Knoten und der Erkundung von Freifunk!
-</p>
-]],
-  },
 }

--- a/site.mk
+++ b/site.mk
@@ -57,5 +57,5 @@ GLUON_PRIORITY ?= 0
 # Languages to include
 GLUON_LANGS ?= en de
 
-GLUON_ATH10K_MESH ?= ibss 
-GLUON_REGION ?= eu 
+GLUON_ATH10K_MESH := ibss 
+GLUON_REGION := eu 

--- a/site.mk
+++ b/site.mk
@@ -7,7 +7,7 @@
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
 	gluon-alfred \
-	gluon-announced \
+	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \
 	gluon-config-mode-contact-info \

--- a/site.mk
+++ b/site.mk
@@ -1,5 +1,3 @@
-##	gluon site.mk makefile example
-
 ##	GLUON_SITE_PACKAGES
 #		specify gluon/openwrt packages to include here
 #		The gluon-mesh-batman-adv-* package must come first because of the dependency resolution
@@ -167,17 +165,14 @@ GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB
 # mpc85xx-generic
 GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
 
-
-
-
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images
 #		gluon relies on
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
+# Firmware name pattern
 DEFAULT_GLUON_RELEASE := 2016.2-exp$(shell date '+%Y%m%d')
-
 
 ##	GLUON_RELEASE
 #		call make with custom GLUON_RELEASE flag, to use your own release version scheme.
@@ -197,3 +192,4 @@ GLUON_LANGS ?= en de
 
 # Region settings for ARCHERC7
 GLUON_REGION ?= eu
+

--- a/site.mk
+++ b/site.mk
@@ -56,6 +56,5 @@ GLUON_PRIORITY ?= 0
 
 # Languages to include
 GLUON_LANGS ?= en de
-
-GLUON_ATH10K_MESH := ibss 
-GLUON_REGION := eu 
+GLUON_REGION ?= eu
+GLUON_LANGS ?= en de

--- a/site.mk
+++ b/site.mk
@@ -193,4 +193,4 @@ GLUON_LANGS ?= en de
 # Region settings for ARCHERC7
 GLUON_REGION ?= eu
 
-GLUON_ATH10K_MESH ?= ibss
+GLUON_ATH10K_MESH = ibss

--- a/site.mk
+++ b/site.mk
@@ -17,6 +17,8 @@ GLUON_SITE_PACKAGES := \
 	gluon-config-mode-mesh-vpn \
 	gluon-ebtables-filter-multicast \
 	gluon-ebtables-filter-ra-dhcp \
+	gluon-luci-private-wifi \
+	gluon-neighbour-info \
 	gluon-luci-admin \
 	gluon-luci-autoupdater \
 	gluon-luci-portconfig \
@@ -36,7 +38,7 @@ GLUON_SITE_PACKAGES := \
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := 0.6+mstr$(shell date '+%Y%m%d')
+DEFAULT_GLUON_RELEASE := 2016.1-exp$(shell date '+%Y%m%d')
 
 
 ##	GLUON_RELEASE
@@ -54,3 +56,6 @@ GLUON_PRIORITY ?= 0
 
 # Languages to include
 GLUON_LANGS ?= en de
+
+GLUON_ATH10K_MESH ?= ibss 
+GLUON_REGION ?= eu 

--- a/site.mk
+++ b/site.mk
@@ -4,7 +4,6 @@
 
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
-	gluon-alfred \
 	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \

--- a/site.mk
+++ b/site.mk
@@ -32,6 +32,144 @@ GLUON_SITE_PACKAGES := \
 	iptables \
 	iwinfo 
 
+# basic support for USB stack
+USB_PACKAGES_BASIC := \
+	kmod-usb-core \
+	kmod-usb2
+
+# storage support for USB devices
+USB_PACKAGES_STORAGE := \
+	block-mount \
+	blkid \
+	kmod-fs-ext4 \
+	kmod-fs-vfat \
+	kmod-usb-storage \
+	kmod-usb-storage-extras \
+	kmod-nls-cp1250 \
+	kmod-nls-cp1251 \
+	kmod-nls-cp437 \
+	kmod-nls-cp775 \
+	kmod-nls-cp850 \
+	kmod-nls-cp852 \
+	kmod-nls-cp866 \
+	kmod-nls-iso8859-1 \
+	kmod-nls-iso8859-13 \
+	kmod-nls-iso8859-15 \
+	kmod-nls-iso8859-2 \
+	kmod-nls-koi8r \
+	kmod-nls-utf8 \
+	swap-utils
+
+# network support for USB devices
+USB_PACKAGES_NET := \
+	kmod-mii \
+	kmod-nls-base \
+	kmod-usb-net \
+	kmod-usb-net-asix \
+	kmod-usb-net-asix-ax88179 \
+	kmod-usb-net-cdc-eem \
+	kmod-usb-net-cdc-ether \
+	kmod-usb-net-cdc-mbim \
+	kmod-usb-net-cdc-ncm \
+	kmod-usb-net-cdc-subset \
+	kmod-usb-net-dm9601-ether \
+	kmod-usb-net-hso \
+	kmod-usb-net-huawei-cdc-ncm \
+	kmod-usb-net-ipheth \
+	kmod-usb-net-kalmia \
+	kmod-usb-net-kaweth \
+	kmod-usb-net-mcs7830 \
+	kmod-usb-net-pegasus \
+	kmod-usb-net-qmi-wwan \
+	kmod-usb-net-rndis \
+	kmod-usb-net-sierrawireless \
+	kmod-usb-net-smsc95xx
+# broken
+#	kmod-usb-net-rtl8150 \
+#	kmod-usb-net-rtl8152 \
+# network support for PCI devices
+PCI_PACKAGES_NET := \
+	kmod-3c59x \
+	kmod-e100 \
+	kmod-e1000 \
+	kmod-e1000e \
+	kmod-forcedeth \
+	kmod-natsemi \
+	kmod-ne2k-pci \
+	kmod-pcnet32 \
+	kmod-r8169 \
+	kmod-sis900 \
+	kmod-sky2 \
+	kmod-tg3 \
+	kmod-tulip \
+	kmod-via-rhine
+# broken
+#	kmod-ixgbe \
+#	kmod-r8139too \
+# additional packages
+TOOLS_PACKAGES := \
+	iperf \
+	socat \
+	tcpdump \
+	usbutils \
+	vnstat
+# broken
+#	pciutils \
+#
+# $(GLUON_TARGET) specific settings:
+#
+
+# x86-generic
+ifeq ($(GLUON_TARGET),x86-generic)
+# support the usb stack on x86 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES)
+endif
+
+# x86-64
+ifeq ($(GLUON_TARGET),x86-64)
+# support the usb stack on x86-64 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES)
+endif
+
+ifeq ($(GLUON_TARGET),x86-kvm_guest)
+GLUON_SITE_PACKAGES += \
+	$(TOOLS_PACKAGES)
+endif
+
+# ar71xx-generic
+GLUON_TLWR842_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR1043_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR2543_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWDR4300_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WNDR3700_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WRT160NL_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_ARCHERC7_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_GLINET_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPG450H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+# mpc85xx-generic
+GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+
+
+
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images
 #		gluon relies on
@@ -56,5 +194,6 @@ GLUON_PRIORITY ?= 0
 
 # Languages to include
 GLUON_LANGS ?= en de
+
+# Region settings for ARCHERC7
 GLUON_REGION ?= eu
-GLUON_LANGS ?= en de

--- a/site.mk
+++ b/site.mk
@@ -193,3 +193,4 @@ GLUON_LANGS ?= en de
 # Region settings for ARCHERC7
 GLUON_REGION ?= eu
 
+GLUON_ATH10K_MESH ?= ibss

--- a/site.mk
+++ b/site.mk
@@ -38,7 +38,7 @@ GLUON_SITE_PACKAGES := \
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := 2016.1-exp$(shell date '+%Y%m%d')
+DEFAULT_GLUON_RELEASE := 2016.2-exp$(shell date '+%Y%m%d')
 
 
 ##	GLUON_RELEASE


### PR DESCRIPTION
(+) Gluon 2016.2.x Anpassungen
(+) setup on first boot true

 GLUON_SITE_PACKAGES := \
(-)	gluon-alfred \
(-)	gluon-announced \
(+)	gluon-respondd \
(+)	gluon-luci-private-wifi \
(+)	gluon-neighbour-info \

(+) Targets mit ausreichend Speicher bekommen Zusatzpakete vorinstalliert.